### PR TITLE
Potential fix for code scanning alert no. 7: Implicit narrowing conversion in compound assignment

### DIFF
--- a/dlls/wineandroid.drv/WineActivity.java
+++ b/dlls/wineandroid.drv/WineActivity.java
@@ -593,7 +593,7 @@ public class WineActivity extends Activity
         }
 
         /* wrapper for layout() making sure that the view is not empty */
-        public void set_layout( int left, int top, int right, int bottom )
+        public void set_layout( float left, float top, float right, float bottom )
         {
             left   *= win.scale;
             top    *= win.scale;
@@ -601,7 +601,7 @@ public class WineActivity extends Activity
             bottom *= win.scale;
             if (right <= left + 1) right = left + 2;
             if (bottom <= top + 1) bottom = top + 2;
-            layout( left, top, right, bottom );
+            layout( (int)left, (int)top, (int)right, (int)bottom );
         }
 
         @Override


### PR DESCRIPTION
Potential fix for [https://github.com/slowedcodinganai/wine/security/code-scanning/7](https://github.com/slowedcodinganai/wine/security/code-scanning/7)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we should change the type of `left`, `top`, `right`, and `bottom` to `float` to match the type of `win.scale`. This will prevent any implicit narrowing conversion and preserve the precision of the calculations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
